### PR TITLE
Handle v0.14 output plugins

### DIFF
--- a/lib/fluent/plugin/out_copy_ex.rb
+++ b/lib/fluent/plugin/out_copy_ex.rb
@@ -10,6 +10,7 @@ module Fluent
       super
       @outputs = []
       @ignore_errors = []
+      @emit_procs = []
     end
 
     attr_reader :outputs, :ignore_errors
@@ -27,6 +28,12 @@ module Fluent
 
         output = Plugin.new_output(type)
         output.configure(e)
+        emit_proc = if output.respond_to?(:emit_events)
+                      Proc.new {|output, tag, es, _chain| output.emit_events(tag, es)}
+                    else
+                      Proc.new {|output, tag, es, _chain| output.emit(tag, es, NullOutputChain.instance)}
+                    end
+        @emit_procs << emit_proc
         @outputs << output
 
         @ignore_errors << (e.arg == "ignore_error")
@@ -58,11 +65,7 @@ module Fluent
       @outputs.each_index do |idx|
         _es = @deep_copy ? es.dup : es
         begin
-          if @outputs[idx].respond_to?(:emit_events)
-            @outputs[idx].emit_events(tag, _es)
-          else
-            @outputs[idx].emit(tag, _es, NullOutputChain.instance)
-          end
+          @emit_procs[idx].call(@outputs[idx], tag, _es, NullOutputChain.instance)
         rescue => e
           if @ignore_errors[idx]
             log.error :error_class => e.class, :error => e.message

--- a/lib/fluent/plugin/out_copy_ex.rb
+++ b/lib/fluent/plugin/out_copy_ex.rb
@@ -58,7 +58,11 @@ module Fluent
       @outputs.each_index do |idx|
         _es = @deep_copy ? es.dup : es
         begin
-          @outputs[idx].emit(tag, _es, NullOutputChain.instance)
+          if @outputs[idx].respond_to?(:emit_events)
+            @outputs[idx].emit_events(tag, _es)
+          else
+            @outputs[idx].emit(tag, _es, NullOutputChain.instance)
+          end
         rescue => e
           if @ignore_errors[idx]
             log.error :error_class => e.class, :error => e.message

--- a/test/plugin/test_out_copy_ex.rb
+++ b/test/plugin/test_out_copy_ex.rb
@@ -17,6 +17,10 @@ class CopyExOutputTest < Test::Unit::TestCase
     Fluent::Test.setup
   end
 
+  def config_element(name = 'test', argument = '', params = {}, elements = [])
+    Fluent::Config::Element.new(name, argument, params, elements)
+  end
+
   CONFIG = %[
     <store>
       type test
@@ -56,9 +60,9 @@ class CopyExOutputTest < Test::Unit::TestCase
 
     outputs = d.instance.outputs
     assert_equal 3, outputs.size
-    assert_equal Fluent::TestOutput, outputs[0].class
-    assert_equal Fluent::TestOutput, outputs[1].class
-    assert_equal Fluent::TestOutput, outputs[2].class
+    assert_equal Fluent::Plugin::TestOutput, outputs[0].class
+    assert_equal Fluent::Plugin::TestOutput, outputs[1].class
+    assert_equal Fluent::Plugin::TestOutput, outputs[2].class
     assert_equal "c0", outputs[0].name
     assert_equal "c1", outputs[1].name
     assert_equal "c2", outputs[2].name
@@ -95,7 +99,7 @@ class CopyExOutputTest < Test::Unit::TestCase
 
     outputs = %w(p1 p2).map do |pname|
       p = Fluent::Plugin.new_output('test')
-      p.configure('name' => pname)
+      p.configure(config_element('ROOT', '', {'name' => pname}))
       p.define_singleton_method(:emit) do |tag, es, chain|
         es.each do |time, record|
           super(tag, [[time, record]], chain)
@@ -133,19 +137,19 @@ deep_copy true
 ]
 
     output1 = Fluent::Plugin.new_output('test')
-    output1.configure('name' => 'output1')
-    output1.define_singleton_method(:emit) do |tag, es, chain|
+    output1.configure(config_element('ROOT', '', {'name' => 'output1'}))
+    output1.define_singleton_method(:emit_events) do |tag, es|
       es.each do |time, record|
         record['foo'] = 'bar'
-        super(tag, [[time, record]], chain)
+        super(tag, [[time, record]])
       end
     end
 
     output2 = Fluent::Plugin.new_output('test')
-    output2.configure('name' => 'output2')
-    output2.define_singleton_method(:emit) do |tag, es, chain|
+    output2.configure(config_element('ROOT', '', {'name' => 'output2'}))
+    output2.define_singleton_method(:emit_events) do |tag, es|
       es.each do |time, record|
-        super(tag, [[time, record]], chain)
+        super(tag, [[time, record]])
       end
     end
 


### PR DESCRIPTION
Hi, I've found that `copy_ex` does not have functionality to handle v0.14 API based plugin.
And I modified tests using `out_test` plugin, which is used only for testing in Fluentd,  are also migrated v0.14 API based.